### PR TITLE
Update the dockerfiles to pull from the develop branch rather than DotNetCore branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN \
  mkdir -p /app/ombi && \
  curl -o \
  /tmp/ombi-src.tar.gz -L \
-	"https://ci.appveyor.com/api/projects/tidusjar/requestplex/artifacts/linux.tar.gz?branch=DotNetCore&pr=false" && \
+	"https://ci.appveyor.com/api/projects/tidusjar/requestplex/artifacts/linux.tar.gz?branch=develop&pr=false" && \
  tar xzf /tmp/ombi-src.tar.gz -C /app/ombi/ && \
  chmod +x /app/ombi/Ombi && \
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Webui is at `<your-ip>:3579`, Follow the setup wizard on initial install.  Then 
 
 ## Versions
 
++ **04.03.18:** Change ombi branch to preview
 + **27.11.17:** Ignore PR build artifacts when pulling the latest
 + **14.11.17:** Pull the release artifact from the DotNetCore branch
 + **02.11.17:** Switch to Ombi v3 based on .net core, available for beta testing

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -8,7 +8,7 @@ mkdir -p /app/ombi
 # (re)install preview version of ombi
 curl -o \
 	/tmp/ombi-src.tar.gz -L \
-	"https://ci.appveyor.com/api/projects/tidusjar/requestplex/artifacts/linux.tar.gz?branch=DotNetCore&pr=false"
+	"https://ci.appveyor.com/api/projects/tidusjar/requestplex/artifacts/linux.tar.gz?branch=develop&pr=false"
 tar xzf \
 	/tmp/ombi-src.tar.gz -C \
 	/app/ombi/


### PR DESCRIPTION
DotNetCore branch no longer exists, the develop branch should now be the 'preview'