### PR TITLE
Use BASE_URL env to set base url

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ docker create \
   -e PUID=1000 \
   -e PGID=1000 \
   -e TZ=Europe/London \
+  -e BASE_URL=/ombi `#optional` \
   -p 3579:3579 \
-  -v </path/to/appdata/config>:/config \
+  -v /path/to/appdata/config:/config \
   --restart unless-stopped \
   linuxserver/ombi
 ```
@@ -87,8 +88,9 @@ services:
       - PUID=1000
       - PGID=1000
       - TZ=Europe/London
+      - BASE_URL=/ombi #optional
     volumes:
-      - </path/to/appdata/config>:/config
+      - /path/to/appdata/config:/config
     ports:
       - 3579:3579
     restart: unless-stopped
@@ -104,6 +106,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e PUID=1000` | for UserID - see below for explanation |
 | `-e PGID=1000` | for GroupID - see below for explanation |
 | `-e TZ=Europe/London` | Specify a timezone to use EG Europe/London |
+| `-e BASE_URL=/ombi` | Subfolder can optionally be defined as an env variable for reverse proxies. Keep in mind that once this value is defined, the gui setting for base url no longer works. To use the gui setting, remove this env variable. |
 | `-v /config` | Contains all relevant configuration files. |
 
 ## User / Group Identifiers
@@ -188,6 +191,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **10.05.19:** - Added an optional env variable for base url setting.
 * **23.03.19:** - Switching to new Base images, shift to arm32v7 tag.
 * **22.02.19:** - Clarify info on tags and development builds.
 * **25.01.19:** - Add info on tags and development builds.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -32,7 +32,7 @@ common_param_env_vars_enabled: true
 param_container_name: "{{ project_name }}"
 param_usage_include_vols: true
 param_volumes:
-  - { vol_path: "/config", vol_host_path: "</path/to/appdata/config>", desc: "Contains all relevant configuration files." }
+  - { vol_path: "/config", vol_host_path: "/path/to/appdata/config", desc: "Contains all relevant configuration files." }
 param_usage_include_ports: true
 param_ports:
   - { external_port: "3579", internal_port: "3579", port_desc: "web gui" }
@@ -40,7 +40,11 @@ param_usage_include_env: true
 param_env_vars:
   - { env_var: "TZ", env_value: "Europe/London", desc: "Specify a timezone to use EG Europe/London"}
 
-# optional parameters
+# optional container parameters
+opt_param_usage_include_env: true
+opt_param_env_vars:
+  - { env_var: "BASE_URL", env_value: "/ombi", desc: "Subfolder can optionally be defined as an env variable for reverse proxies. Keep in mind that once this value is defined, the gui setting for base url no longer works. To use the gui setting, remove this env variable." }
+
 optional_block_1: false
 optional_block_1_items: ""
 
@@ -51,6 +55,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "10.05.19:", desc: "Added an optional env variable for base url setting." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }
   - { date: "22.02.19:", desc: "Clarify info on tags and development builds." }
   - { date: "25.01.19:", desc: "Add info on tags and development builds." }

--- a/root/etc/services.d/ombi/run
+++ b/root/etc/services.d/ombi/run
@@ -3,4 +3,4 @@
 cd /opt/ombi || exit
 
 exec \
-	s6-setuidgid abc /opt/ombi/Ombi --storage "/config" --host http://*:3579
+	s6-setuidgid abc /opt/ombi/Ombi --storage "/config" --host http://*:3579 --baseurl "${BASE_URL:-/}"

--- a/root/etc/services.d/ombi/run
+++ b/root/etc/services.d/ombi/run
@@ -2,5 +2,9 @@
 
 cd /opt/ombi || exit
 
+if [[ ! -z "${BASE_URL}" ]]; then
+    EXTRA_PARAM="--baseurl ${BASE_URL}"
+fi
+
 exec \
-	s6-setuidgid abc /opt/ombi/Ombi --storage "/config" --host http://*:3579 --baseurl ${BASE_URL:-/}
+	s6-setuidgid abc /opt/ombi/Ombi --storage "/config" --host http://*:3579 ${EXTRA_PARAM}

--- a/root/etc/services.d/ombi/run
+++ b/root/etc/services.d/ombi/run
@@ -3,4 +3,4 @@
 cd /opt/ombi || exit
 
 exec \
-	s6-setuidgid abc /opt/ombi/Ombi --storage "/config" --host http://*:3579 --baseurl "${BASE_URL:-/}"
+	s6-setuidgid abc /opt/ombi/Ombi --storage "/config" --host http://*:3579 --baseurl ${BASE_URL:-/}


### PR DESCRIPTION
By using the environment variable, for instance, in docker-compose.yml or -e BASE_URL="/ombi", the base url is automatically configured.
This fixes the issue with reverse proxies and path prefixes.

The default value is still the root path /

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

closes #55 