### PR TITLE
Change the Ombi Port to a variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **16.01.21:** - Added an optional env variable for internal port setting.
 * **14.04.20:** - Add Ombi donate links.
 * **10.05.19:** - Added an optional env variable for base url setting.
 * **23.03.19:** - Switching to new Base images, shift to arm32v7 tag.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ services:
       - PGID=1000
       - TZ=Europe/London
       - BASE_URL=/ombi #optional
+      - OMBI_PORT=80 #optional
     volumes:
       - /path/to/appdata/config:/config
     ports:
@@ -105,6 +106,7 @@ docker run -d \
   -e PGID=1000 \
   -e TZ=Europe/London \
   -e BASE_URL=/ombi `#optional` \
+  -e OMBI_PORT=80 `#optional` \
   -p 3579:3579 \
   -v /path/to/appdata/config:/config \
   --restart unless-stopped \
@@ -123,6 +125,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e PGID=1000` | for GroupID - see below for explanation |
 | `-e TZ=Europe/London` | Specify a timezone to use EG Europe/London |
 | `-e BASE_URL=/ombi` | Subfolder can optionally be defined as an env variable for reverse proxies. Keep in mind that once this value is defined, the gui setting for base url no longer works. To use the gui setting, remove this env variable. |
+| `-e OMBI_PORT=80` | Change the internal port that Ombi will attach to within the container. Must be reflected in Docker Ports associations as well. |
 | `-v /config` | Contains all relevant configuration files. |
 
 ## Environment variables from files (Docker secrets)

--- a/README.md
+++ b/README.md
@@ -236,7 +236,6 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
-* **16.01.21:** - Added an optional env variable for internal port setting.
 * **14.04.20:** - Add Ombi donate links.
 * **10.05.19:** - Added an optional env variable for base url setting.
 * **23.03.19:** - Switching to new Base images, shift to arm32v7 tag.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -55,6 +55,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "16.01.21:", desc: "Added an optional env variable for internal port setting." }
   - { date: "14.04.20:", desc: "Add Ombi donate links." }
   - { date: "10.05.19:", desc: "Added an optional env variable for base url setting." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }

--- a/root/etc/services.d/ombi/run
+++ b/root/etc/services.d/ombi/run
@@ -6,5 +6,7 @@ if [[ ! -z "${BASE_URL}" ]]; then
     EXTRA_PARAM="--baseurl ${BASE_URL}"
 fi
 
+OMBI_PORT="${OMBI_PORT:=3579}" # Default to port 3579 if not set by user
+
 exec \
 	s6-setuidgid abc /opt/ombi/Ombi --storage "/config" --host http://*:${OMBI_PORT} ${EXTRA_PARAM}

--- a/root/etc/services.d/ombi/run
+++ b/root/etc/services.d/ombi/run
@@ -7,4 +7,4 @@ if [[ ! -z "${BASE_URL}" ]]; then
 fi
 
 exec \
-	s6-setuidgid abc /opt/ombi/Ombi --storage "/config" --host http://*:3579 ${EXTRA_PARAM}
+	s6-setuidgid abc /opt/ombi/Ombi --storage "/config" --host http://*:${OMBI_PORT} ${EXTRA_PARAM}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-ombi/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Added a docker environment variable that will change the internal port that ombi is started on

## Benefits of this PR and context:
This gives the user a little more flexibility. Personally, I run a lot of containers using macvlan and each has their own host and IP on my host's network. When i try to go to a container via hostname or IP, I must remember all of their unique default ports. Many can be changed but this container proved problematic.

## How Has This Been Tested?
On my local set up, I run all of these exact changes.
I run all of my containers on the same network as my docker host, so each container has its own IP and hostname that is accessible by other hosts on my LAN. I have tested this PR with and without the core modification to the run script, as well as with setting the variable via docker versus leaving it unset. all behaved as intended.

This change should not affect any other piece of code in this project. It simply changes a hard set number (port) to a variable. If the variable is unused by the user, it is set to the value it was at prior to this PR.


## Source / References:
This was referenced to determine how to set the variable to default when not used by the user: https://stackoverflow.com/a/2013573