### PR TITLE
fix: chown the correct index.html path (dist/browser) — regression of #124

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-ombi-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-ombi-config/run
@@ -9,5 +9,5 @@ lsiown -R abc:abc \
     /config
 
 if [[ -z ${LSIO_READ_ONLY_FS} ]]; then
-    lsiown abc:abc /app/ombi/ClientApp/dist/index.html
+    lsiown abc:abc /app/ombi/ClientApp/dist/browser/index.html
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The init script chowns the wrong `index.html` path, so Ombi cannot apply `BASE_URL` and the UI shows a blank page behind a sub-path reverse proxy.

The Angular build output moved into a `browser/` subfolder; the file Ombi rewrites at startup lives at `/app/ombi/ClientApp/dist/browser/index.html`. PR #124 already fixed this, but commit 32375bf ("Fix subfolder permissions fix", which added the `LSIO_READ_ONLY_FS` guard) reintroduced the old `dist/index.html` path. As a result the real file is never chowned to `abc`, the `<base href>` is never updated, and assets 404 from the domain root.

This restores the `browser/` path inside the existing read-only guard — keeping that guard intact.

```diff
 if [[ -z ${LSIO_READ_ONLY_FS} ]]; then
-    lsiown abc:abc /app/ombi/ClientApp/dist/index.html
+    lsiown abc:abc /app/ombi/ClientApp/dist/browser/index.html
 fi
```

## Benefits of this PR and context

Fixes the blank-page / "unauthorized access to index.html" startup error for sub-path (`BASE_URL`) deployments on current images.

Closes #126

## How Has This Been Tested?

Verified against the published images: in `4.53.5` (working) `index.html` sits at `dist/index.html`; in `4.53.10` it is at `dist/browser/index.html` while the chown still targets `dist/index.html`, leaving the file owned by `1001:1001` and unwritable by the `abc` (PUID) user.

## Source / References

- Regressed in 32375bf; originally fixed in #124.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
